### PR TITLE
fix: added artworks add view column migration

### DIFF
--- a/hasura/migrations/default/1612989184913_alter_table_public_artworks_add_column_views/down.sql
+++ b/hasura/migrations/default/1612989184913_alter_table_public_artworks_add_column_views/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."artworks" DROP COLUMN "views";

--- a/hasura/migrations/default/1612989184913_alter_table_public_artworks_add_column_views/up.sql
+++ b/hasura/migrations/default/1612989184913_alter_table_public_artworks_add_column_views/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."artworks" ADD COLUMN "views" integer DEFAULT 0;


### PR DESCRIPTION
When running migrations for the first time, a migration that create the views column inside artworks table, was missing