### PR TITLE
Sign In form typo fix.

### DIFF
--- a/src/routes/login/index.svelte
+++ b/src/routes/login/index.svelte
@@ -42,7 +42,7 @@
   <form class="mb-6" on:submit|preventDefault={login} autocomplete="off">
     <h2 class="mb-8">Sign In</h2>
     <div class="flex flex-col mb-4">
-      <label class="mb-2 font-medium" for="first_name">Email or email</label>
+      <label class="mb-2 font-medium" for="first_name">Email or username</label>
       <input bind:value={email} bind:this={emailInput} autocapitalize="off" />
     </div>
     <div class="flex flex-col mb-4">


### PR DESCRIPTION
The sage Sign In form has "Emai or email" instead of "Email or username"