### PR TITLE
changed .sticky from fixed, to relative for a smooth transition

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -250,7 +250,7 @@ select {
 }
 
 .sticky {
-  position: fixed;
+  position: relative;
   top: 0;
   left: 0;
   width: 100%;

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -100,7 +100,7 @@
 <Snack />
 
 <Sidebar bind:open />
-<div class={y > 50 ? "sticky" : ""}>
+<div class={y > 50 ? "sticky" : "relative"}>
   <Navbar bind:sidebar={open} />
 </div>
 <Dialog />


### PR DESCRIPTION
Reason for fix.. @asoltys 

have fixed the nav bar jerkyness with relative instead of fixed .sticky 
for Apple Safari Browser. and is now a smooth transition. instead that jerkyness look.  

I have also checked with other browsers.. & it seems ok!

relative
The element is positioned according to the normal flow of the document,