### PR TITLE
centred text - No offers yet

### DIFF
--- a/src/components/Offers.svelte
+++ b/src/components/Offers.svelte
@@ -20,5 +20,5 @@
     </div>
   </div>
 {:else}
-  <div class="col-span-4 mx-auto">No offers yet</div>
+  <div class="w-full flex justify-center">No offers yet</div>
 {/each}


### PR DESCRIPTION
with w-full flex justify-center, No offers yet
reason for fix, to keep consistence site style.